### PR TITLE
Fix missing asdict import in data generator

### DIFF
--- a/flopayments_ml/generators/synthetic_data_generator.py
+++ b/flopayments_ml/generators/synthetic_data_generator.py
@@ -9,6 +9,7 @@ import logging
 
 from ..core.data_models import Fattura, Transazione
 from ..core.data_types import MatchType, QualityLevel, TimingPattern, AmountPattern, GroundTruth
+from dataclasses import asdict
 from ..core.exceptions import ValidationError
 from .ai_text_generator import AITextGenerator
 from ..utils.file_utils import check_write_permission


### PR DESCRIPTION
## Summary
- add missing `asdict` import for ground truth dataframe generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a155bd9f08323b1170f5f6cdd46d3