### PR TITLE
Fix example usage

### DIFF
--- a/example_usage.py
+++ b/example_usage.py
@@ -2,13 +2,14 @@ from synthetic_invoice_payment_generator import SyntheticDataGenerator, DEFAULT_
 
 # Configure your Azure OpenAI credentials
 AZURE_ENDPOINT = "https://your-resource.openai.azure.com/"
-API_KEY = "your-api-key"
+# Ensure AZURE_OPENAI_API_KEY is set in your environment, e.g.:
+# export AZURE_OPENAI_API_KEY="your-api-key"
 
 # Initialize generator
-generator = SyntheticDataGenerator(DEFAULT_CONFIG, AZURE_ENDPOINT, API_KEY)
+generator = SyntheticDataGenerator(DEFAULT_CONFIG, AZURE_ENDPOINT)
 
 # Generate dataset
-dataset = generator.generate_dataset(total_size=5000)
+dataset = generator.generate_dataset()
 
 # Export in multiple formats
 generator.export_dataset(dataset, "./synthetic_data")


### PR DESCRIPTION
## Summary
- fix `example_usage.py` to demonstrate two-argument usage of `SyntheticDataGenerator`
- show how to use environment variable for the API key
- remove `total_size` from `generate_dataset` call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e7513e288323bbd69942f306fa0b