### PR TITLE
Handle rate limits and expose fallback info

### DIFF
--- a/flopayments_ml/core/data_models.py
+++ b/flopayments_ml/core/data_models.py
@@ -148,5 +148,13 @@ class Transazione(BaseModel):
         ],
         description = "causale della transazione"
     )
-    invoice_number: bool #whether or not the descrizione/causal contains invoice number
+    invoice_number: bool  # whether or not the descrizione/causale contains invoice number
+    is_fallback: bool = Field(
+        default=False,
+        description="Indicates that the record was generated using fallback logic",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Error message returned when falling back to synthetic data",
+    )
     

--- a/flopayments_ml/generators/ai_text_generator.py
+++ b/flopayments_ml/generators/ai_text_generator.py
@@ -2,6 +2,7 @@ import os
 import random
 import logging
 from typing import Tuple, Optional
+from openai import RateLimitError
 from langchain_openai import AzureChatOpenAI
 from langchain.prompts import ChatPromptTemplate
 from datetime import datetime
@@ -130,6 +131,16 @@ class AITextGenerator:
         self.llm_invoice = self.llm.with_structured_output(Fattura)
         self.llm_trans = self.llm.with_structured_output(Transazione)
 
+    @retry(
+        wait=wait_exponential(multiplier=1, min=1, max=20),
+        stop=stop_after_attempt(3),
+        retry=retry_if_exception_type(RateLimitError),
+        reraise=True,
+    )
+    def _invoke_with_retry(self, chain, inputs):
+        """Invoke an LLM chain with retry on rate limit errors."""
+        return chain.invoke(inputs)
+
     def _heuristic_transaction_type(self, fattura: Fattura) -> Optional[str]:
         """Try to infer the transaction type from invoice information using simple heuristics."""
         text = f"{fattura.descrizione} {fattura.prestatore} {fattura.committente}".lower()
@@ -176,8 +187,12 @@ class AITextGenerator:
 
     def _build_transaction_prompt(self, transaction_type: str, include_invoice_number: bool) -> ChatPromptTemplate:
         examples = self.transaction_templates.get(transaction_type, self.transaction_templates["ALTRO/GENERICO"])
-        dett = "\n".join(f"- {ex}" for ex in examples["dettagli"])
-        caus = "\n".join(f"- {ex}" for ex in examples["causali"])
+        def _escape(text: str) -> str:
+            """Escape curly braces so prompt templates don't expect variables."""
+            return text.replace("{", "{{").replace("}", "}}")
+
+        dett = "\n".join(f"- {_escape(ex)}" for ex in examples["dettagli"])
+        caus = "\n".join(f"- {_escape(ex)}" for ex in examples["causali"])
 
         invoice_instruction = "- Includi il numero fattura nel dettaglio e/o causale" if include_invoice_number else "- NON includere il numero fattura - usa solo descrizioni generiche del servizio"
 
@@ -241,7 +256,7 @@ class AITextGenerator:
             return self._get_fallback_invoice_data(tipo_servizio, data_emissione)
     
     def generate_transaction_data(self, fattura: Fattura, importo: float,
-                                invoice_number_probability: float = 0.1) -> Tuple[str, str, str, bool, bool]:
+                                invoice_number_probability: float = 0.1) -> Tuple[str, str, str, bool, bool, Optional[str]]:
         """Generate realistic transaction dettaglio, causale and controparte"""
         include_invoice_number = random.random() < invoice_number_probability
 
@@ -266,11 +281,20 @@ class AITextGenerator:
         chain = prompt_template | self.llm_trans
 
         try:
-            response: Transazione = chain.invoke({"attributi_transazione": attributi_transazione})
-            return response.dettaglio, response.causale, response.controparte, include_invoice_number, False
+            response: Transazione = self._invoke_with_retry(
+                chain, {"attributi_transazione": attributi_transazione}
+            )
+            return (
+                response.dettaglio,
+                response.causale,
+                response.controparte,
+                include_invoice_number,
+                False,
+                None,
+            )
         except Exception as e:
             logger.error(f"Error generating transaction data: {e}")
-            return self._get_fallback_transaction_data(fattura, include_invoice_number)
+            return self._get_fallback_transaction_data(fattura, include_invoice_number, str(e))
     
     def _get_fallback_invoice_data(self, tipo_servizio: str, data_emissione) -> Tuple[str, str, str]:
         """Generate fallback invoice data when AI generation fails"""
@@ -296,7 +320,12 @@ class AITextGenerator:
         fallback_numero = f"FT{data_emissione_dt.year}/{random.randint(1000, 9999)}"
         return fallback_desc, "BETA SOLUTIONS SRL", fallback_numero
     
-    def _get_fallback_transaction_data(self, fattura: Fattura, include_invoice_number: bool) -> Tuple[str, str, str, bool, bool]:
+    def _get_fallback_transaction_data(
+        self,
+        fattura: Fattura,
+        include_invoice_number: bool,
+        error: str,
+    ) -> Tuple[str, str, str, bool, bool, str]:
         """Generate fallback transaction data when AI generation fails"""
         if include_invoice_number:
             fallback_dettaglio = f"BONIFICO SEPA - Pagamento fattura n. {fattura.numero_fattura}"
@@ -307,7 +336,14 @@ class AITextGenerator:
             fallback_causale = f"Pagamento {service_type}"
 
         fallback_controparte = fattura.prestatore
-        return fallback_dettaglio, fallback_causale, fallback_controparte, include_invoice_number, True
+        return (
+            fallback_dettaglio,
+            fallback_causale,
+            fallback_controparte,
+            include_invoice_number,
+            True,
+            error,
+        )
 
     def generate_invoice_data_batch(self, invoices: list[dict]) -> list[Tuple[str, str, str]]:
         """Generate invoice texts for a batch of invoices."""
@@ -352,11 +388,16 @@ class AITextGenerator:
             logger.error(f"Error generating invoice batch: {e}")
             return [self._get_fallback_invoice_data(i['tipo_servizio'], i['data_emissione']) for i in invoices]
 
-    @retry(wait=wait_exponential(multiplier=1, min=4, max=10), stop=stop_after_attempt(5), retry=retry_if_exception_type(Exception))
+    @retry(
+        wait=wait_exponential(multiplier=1, min=4, max=10),
+        stop=stop_after_attempt(5),
+        retry=retry_if_exception_type(RateLimitError),
+        reraise=True,
+    )
     def _generate_batch_with_retry(self, chain, inputs):
         return chain.batch(inputs)
 
-    def generate_transaction_data_batch(self, transactions: list[dict]) -> list[Tuple[str, str, str, bool, bool]]:
+    def generate_transaction_data_batch(self, transactions: list[dict]) -> list[Tuple[str, str, str, bool, bool, Optional[str]]]:
         """Generate transaction texts for a batch of payments."""
         prompt_with = ChatPromptTemplate.from_messages([
             ("system", """Genera una transazione bancaria italiana realistica.
@@ -410,14 +451,30 @@ class AITextGenerator:
             if inputs_with:
                 res_with = self._generate_batch_with_retry(chain_with, inputs_with)
                 for i, r in zip(idx_with, res_with):
-                    results[i] = (r.dettaglio, r.causale, r.controparte, True, False)
+                    results[i] = (
+                        r.dettaglio,
+                        r.causale,
+                        r.controparte,
+                        True,
+                        False,
+                        None,
+                    )
             if inputs_without:
                 res_without = self._generate_batch_with_retry(chain_without, inputs_without)
                 for i, r in zip(idx_without, res_without):
-                    results[i] = (r.dettaglio, r.causale, r.controparte, False, False)
+                    results[i] = (
+                        r.dettaglio,
+                        r.causale,
+                        r.controparte,
+                        False,
+                        False,
+                        None,
+                    )
         except Exception as e:
             logger.error(f"Error generating transaction batch after retries: {e}")
             for i, t in enumerate(transactions):
-                results[i] = self._get_fallback_transaction_data(t['fattura'], t['include_invoice_number'])
+                results[i] = self._get_fallback_transaction_data(
+                    t['fattura'], t['include_invoice_number'], str(e)
+                )
 
         return results

--- a/flopayments_ml/generators/synthetic_data_generator.py
+++ b/flopayments_ml/generators/synthetic_data_generator.py
@@ -435,7 +435,7 @@ class SyntheticDataGenerator:
         ai_results = self.ai_generator.generate_transaction_data_batch(ai_inputs)
 
         transazioni = []
-        for prep, (dettaglio, causale, controparte, has_invoice_ref, is_fallback) in zip(prepared, ai_results):
+        for prep, (dettaglio, causale, controparte, has_invoice_ref, is_fallback, error) in zip(prepared, ai_results):
             transazione = Transazione(
                 id=str(uuid.uuid4()),
                 data=prep['data_pagamento'],
@@ -445,7 +445,8 @@ class SyntheticDataGenerator:
                 controparte=controparte,
                 causale=causale,
                 invoice_number=1 if has_invoice_ref else 0,
-                is_fallback=is_fallback # Add this line
+                is_fallback=is_fallback,
+                error=error,
             )
             transazioni.append(transazione)
 
@@ -502,7 +503,7 @@ class SyntheticDataGenerator:
             invoice_number_probability = 0.1
         
         # Generate transaction details using AI
-        dettaglio, causale, controparte, has_invoice_ref, is_fallback = self.ai_generator.generate_transaction_data(
+        dettaglio, causale, controparte, has_invoice_ref, is_fallback, error = self.ai_generator.generate_transaction_data(
             fattura, importo, invoice_number_probability
         )
 
@@ -515,7 +516,8 @@ class SyntheticDataGenerator:
             controparte=controparte,
             causale=causale,
             invoice_number=1 if has_invoice_ref else 0,
-            is_fallback=is_fallback # Add this line
+            is_fallback=is_fallback,
+            error=error,
         )
 
         return transazione


### PR DESCRIPTION
## Summary
- add `is_fallback` and `error` fields to `Transazione`
- retry OpenAI calls on rate limit errors
- propagate fallback flags and error reasons from the AI generator
- include error info when generating payments
- escape example placeholders so prompt templates don't expect undefined variables

## Testing
- `pytest -q`
- `python -m py_compile flopayments_ml/generators/ai_text_generator.py flopayments_ml/generators/synthetic_data_generator.py flopayments_ml/core/data_models.py`

------
https://chatgpt.com/codex/tasks/task_e_688b383320c48323b523b6d15aed217f