### PR TITLE
Handle invoice output with dedicated model

### DIFF
--- a/flopayments_ml/core/data_models.py
+++ b/flopayments_ml/core/data_models.py
@@ -148,5 +148,13 @@ class Transazione(BaseModel):
         ],
         description = "causale della transazione"
     )
-    invoice_number: bool #whether or not the descrizione/causal contains invoice number
+    invoice_number: bool  # whether or not the descrizione/causale contains invoice number
+    is_fallback: bool = Field(
+        default=False,
+        description="Indicates that the record was generated using fallback logic",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Error message returned when falling back to synthetic data",
+    )
     

--- a/flopayments_ml/generators/synthetic_data_generator.py
+++ b/flopayments_ml/generators/synthetic_data_generator.py
@@ -435,7 +435,7 @@ class SyntheticDataGenerator:
         ai_results = self.ai_generator.generate_transaction_data_batch(ai_inputs)
 
         transazioni = []
-        for prep, (dettaglio, causale, controparte, has_invoice_ref, is_fallback) in zip(prepared, ai_results):
+        for prep, (dettaglio, causale, controparte, has_invoice_ref, is_fallback, error) in zip(prepared, ai_results):
             transazione = Transazione(
                 id=str(uuid.uuid4()),
                 data=prep['data_pagamento'],
@@ -445,7 +445,8 @@ class SyntheticDataGenerator:
                 controparte=controparte,
                 causale=causale,
                 invoice_number=1 if has_invoice_ref else 0,
-                is_fallback=is_fallback # Add this line
+                is_fallback=is_fallback,
+                error=error,
             )
             transazioni.append(transazione)
 
@@ -502,7 +503,7 @@ class SyntheticDataGenerator:
             invoice_number_probability = 0.1
         
         # Generate transaction details using AI
-        dettaglio, causale, controparte, has_invoice_ref, is_fallback = self.ai_generator.generate_transaction_data(
+        dettaglio, causale, controparte, has_invoice_ref, is_fallback, error = self.ai_generator.generate_transaction_data(
             fattura, importo, invoice_number_probability
         )
 
@@ -515,7 +516,8 @@ class SyntheticDataGenerator:
             controparte=controparte,
             causale=causale,
             invoice_number=1 if has_invoice_ref else 0,
-            is_fallback=is_fallback # Add this line
+            is_fallback=is_fallback,
+            error=error,
         )
 
         return transazione


### PR DESCRIPTION
## Summary
- define `AIInvoiceOutput` for parsing invoice text
- use new model when invoking Azure OpenAI to avoid UUID validation errors

## Testing
- `python -m py_compile flopayments_ml/generators/ai_text_generator.py flopayments_ml/generators/synthetic_data_generator.py flopayments_ml/core/data_models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b383320c48323b523b6d15aed217f